### PR TITLE
Specify facade version for scala versions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,11 @@ resolvers += Resolver.jcenterRepo,
 Then, add it to your SBT dependencies:
 
 ```
+// For scala 2.11
 libraryDependencies += "com.definitelyscala" %%% "scala-js-modernizr" % "1.0.2"
+
+// For scala 2.12
+libraryDependencies += "com.definitelyscala" %%% "scala-js-modernizr" % "1.1.0"
 ```
 
 Classes and traits are available in the package `com.definitelyscala.modernizr`, scaladoc is provided.


### PR DESCRIPTION
The readme states that version "1.0.2" should be used, but a new version "1.1.0" is available that is compatible to scala "2.12", but seems to be not published for "2.11".